### PR TITLE
Display 32-bit value in lddx correctly

### DIFF
--- a/asm/mapunderflow.asm
+++ b/asm/mapunderflow.asm
@@ -1,6 +1,6 @@
 ; /home/alanjo/ebpf-verifier/ebpf-samples/src/mapunderflow.c:29
 ; int func(struct ctx* ctx)
-       0:	r1 = -1 ll
+       0:	r1 = 4294967295 ll
 ; /home/alanjo/ebpf-verifier/ebpf-samples/src/mapunderflow.c:31
 ;     int key = -1;
        2:	*(u32 *)(r10 - 4) = r1


### PR DESCRIPTION
Display 4294967295 (same as llvm-objdump) not -1 for 0x00ffffffff

>\>llvm-objdump -S mapunderflow.o
>
> ...
>       0:       18 01 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 r1 = 4294967295 ll

Signed-off-by: Dave Thaler <dthaler@microsoft.com>