### PR TITLE
Add expected json output for BTF test

### DIFF
--- a/json/badhelpercall.json
+++ b/json/badhelpercall.json
@@ -1,0 +1,30 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 3,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 1,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          
+        ],
+        "return_type":{
+          "id": 2,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    }
+  ]
+}

--- a/json/badmapptr.json
+++ b/json/badmapptr.json
@@ -1,0 +1,200 @@
+{
+  "btf_kinds":[
+    {
+      "id": 4,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"test_repro",
+      "type":{
+        "id": 2,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 3,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"test_map",
+            "linkage":1,
+            "type":{
+              "id": 5,
+              "kind_type": "BTF_KIND_TYPEDEF",
+              "name":"bpf_map_def_t",
+              "type":{
+                "id": 6,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"_bpf_map_def",
+                "size":28,
+                "members":[
+                  {
+                    "name":"type",
+                    "offset":0,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"key_size",
+                    "offset":32,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"value_size",
+                    "offset":64,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"max_entries",
+                    "offset":96,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"map_flags",
+                    "offset":128,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"inner_map_idx",
+                    "offset":160,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"numa_node",
+                    "offset":192,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/byteswap.json
+++ b/json/byteswap.json
@@ -1,0 +1,42 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"ctx",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    }
+  ]
+}

--- a/json/ctxoffset.json
+++ b/json/ctxoffset.json
@@ -1,0 +1,200 @@
+{
+  "btf_kinds":[
+    {
+      "id": 4,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 2,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 3,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 5,
+              "kind_type": "BTF_KIND_TYPEDEF",
+              "name":"bpf_map_def_t",
+              "type":{
+                "id": 6,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"bpf_map",
+                "size":28,
+                "members":[
+                  {
+                    "name":"type",
+                    "offset":0,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"key_size",
+                    "offset":32,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"value_size",
+                    "offset":64,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"max_entries",
+                    "offset":96,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"map_flags",
+                    "offset":128,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"inner_map_idx",
+                    "offset":160,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"numa_node",
+                    "offset":192,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/exposeptr.json
+++ b/json/exposeptr.json
@@ -1,0 +1,201 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"ctx",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 6,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/exposeptr2.json
+++ b/json/exposeptr2.json
@@ -1,0 +1,201 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"ctx",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 6,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/loop.json
+++ b/json/loop.json
@@ -1,0 +1,90 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 8,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"foo",
+      "type":{
+        "id": 6,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"test_md",
+                "size":16,
+                "members":[
+                  {
+                    "name":"data_start",
+                    "offset":0,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name":"uint8_t",
+                        "type":{
+                          "id": 5,
+                          "kind_type": "BTF_KIND_INT",
+                          "name":"",
+                          "size":1,
+                          "bits_offset":0,
+                          "is_signed":0,
+                          "is_char":0,
+                          "is_bool":0
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name":"data_end",
+                    "offset":64,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_PTR",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name":"uint8_t",
+                        "type":{
+                          "id": 5,
+                          "kind_type": "BTF_KIND_INT",
+                          "name":"",
+                          "size":1,
+                          "bits_offset":0,
+                          "is_signed":0,
+                          "is_char":0,
+                          "is_bool":0
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 7,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    }
+  ]
+}

--- a/json/map_in_map.json
+++ b/json/map_in_map.json
@@ -1,0 +1,346 @@
+{
+  "btf_kinds":[
+    {
+      "id": 4,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 2,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 3,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 8,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"array_of_maps",
+            "linkage":1,
+            "type":{
+              "id": 5,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"inner_map",
+            "linkage":1,
+            "type":{
+              "id": 5,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/mapoverflow.json
+++ b/json/mapoverflow.json
@@ -1,0 +1,201 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"ctx",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 6,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/mapunderflow.json
+++ b/json/mapunderflow.json
@@ -1,0 +1,201 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"ctx",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 6,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/mapvalue-overrun.json
+++ b/json/mapvalue-overrun.json
@@ -1,0 +1,200 @@
+{
+  "btf_kinds":[
+    {
+      "id": 4,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 2,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 3,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 5,
+              "kind_type": "BTF_KIND_TYPEDEF",
+              "name":"bpf_map_def_t",
+              "type":{
+                "id": 6,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"bpf_map_def",
+                "size":28,
+                "members":[
+                  {
+                    "name":"type",
+                    "offset":0,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"key_size",
+                    "offset":32,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"value_size",
+                    "offset":64,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"max_entries",
+                    "offset":96,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"map_flags",
+                    "offset":128,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"inner_map_idx",
+                    "offset":160,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"numa_node",
+                    "offset":192,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/nullmapref.json
+++ b/json/nullmapref.json
@@ -1,0 +1,200 @@
+{
+  "btf_kinds":[
+    {
+      "id": 4,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"test_repro",
+      "type":{
+        "id": 2,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 3,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"test_map",
+            "linkage":1,
+            "type":{
+              "id": 5,
+              "kind_type": "BTF_KIND_TYPEDEF",
+              "name":"bpf_map_def_t",
+              "type":{
+                "id": 6,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"_bpf_map_def",
+                "size":28,
+                "members":[
+                  {
+                    "name":"type",
+                    "offset":0,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"key_size",
+                    "offset":32,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"value_size",
+                    "offset":64,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"max_entries",
+                    "offset":96,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"map_flags",
+                    "offset":128,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"inner_map_idx",
+                    "offset":160,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"numa_node",
+                    "offset":192,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/packet_access.json
+++ b/json/packet_access.json
@@ -1,0 +1,158 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 7,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"test_packet_access",
+      "type":{
+        "id": 5,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"xdp_md",
+                "size":24,
+                "members":[
+                  {
+                    "name":"data",
+                    "offset":0,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"data_end",
+                    "offset":32,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"data_meta",
+                    "offset":64,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"_1",
+                    "offset":96,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"_2",
+                    "offset":128,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"_3",
+                    "offset":160,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 6,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    }
+  ]
+}

--- a/json/packet_overflow.json
+++ b/json/packet_overflow.json
@@ -1,0 +1,158 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 7,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"read_write_packet_start",
+      "type":{
+        "id": 5,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"xdp_md",
+                "size":24,
+                "members":[
+                  {
+                    "name":"data",
+                    "offset":0,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"data_end",
+                    "offset":32,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"data_meta",
+                    "offset":64,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"_1",
+                    "offset":96,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"_2",
+                    "offset":128,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"_3",
+                    "offset":160,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 6,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    }
+  ]
+}

--- a/json/packet_reallocate.json
+++ b/json/packet_reallocate.json
@@ -1,0 +1,116 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 9,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"reallocate_invalidates",
+      "type":{
+        "id": 7,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"sk_buff",
+                "size":84,
+                "members":[
+                  {
+                    "name":"_",
+                    "offset":0,
+                    "type":{
+                      "id": 5,
+                      "kind_type": "BTF_KIND_ARRAY",
+                      "element_type":{
+                        "id": 3,
+                        "kind_type": "BTF_KIND_TYPEDEF",
+                        "name":"uint32_t",
+                        "type":{
+                          "id": 4,
+                          "kind_type": "BTF_KIND_INT",
+                          "name":"",
+                          "size":4,
+                          "bits_offset":0,
+                          "is_signed":0,
+                          "is_char":0,
+                          "is_bool":0
+                        }
+                      },
+                      "index_type":{
+                        "id": 6,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      },
+                      "nelems":19
+                    }
+                  },
+                  {
+                    "name":"data",
+                    "offset":608,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"data_end",
+                    "offset":640,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 8,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    }
+  ]
+}

--- a/json/packet_start_ok.json
+++ b/json/packet_start_ok.json
@@ -1,0 +1,158 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 7,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"read_write_packet_start",
+      "type":{
+        "id": 5,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"xdp_md",
+                "size":24,
+                "members":[
+                  {
+                    "name":"data",
+                    "offset":0,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"data_end",
+                    "offset":32,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"data_meta",
+                    "offset":64,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"_1",
+                    "offset":96,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"_2",
+                    "offset":128,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"_3",
+                    "offset":160,
+                    "type":{
+                      "id": 3,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 4,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 6,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    }
+  ]
+}

--- a/json/ringbuf_uninit.json
+++ b/json/ringbuf_uninit.json
@@ -1,0 +1,195 @@
+{
+  "btf_kinds":[
+    {
+      "id": 4,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"test",
+      "type":{
+        "id": 2,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 3,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 9,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 8,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"ring_buffer",
+            "linkage":1,
+            "type":{
+              "id": 5,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 6,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/stackok.json
+++ b/json/stackok.json
@@ -1,0 +1,36 @@
+{
+  "btf_kinds":[
+    {
+      "id": 4,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 2,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 3,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    }
+  ]
+}

--- a/json/tail_call.json
+++ b/json/tail_call.json
@@ -1,0 +1,235 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"caller",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"xdp_md",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 7,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"callee",
+      "type":{
+        "id": 6,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"xdp_md",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 12,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 11,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 8,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"bpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/tail_call_bad.json
+++ b/json/tail_call_bad.json
@@ -1,0 +1,235 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"caller",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"xdp_md",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 7,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"callee",
+      "type":{
+        "id": 6,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"xdp_md",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 12,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 11,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 8,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"bpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 9,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 10,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/twomaps.json
+++ b/json/twomaps.json
@@ -1,0 +1,352 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"ctx",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 11,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map1",
+            "linkage":1,
+            "type":{
+              "id": 6,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 10,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map2",
+            "linkage":1,
+            "type":{
+              "id": 6,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/twostackvars.json
+++ b/json/twostackvars.json
@@ -1,0 +1,42 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"ctx",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    }
+  ]
+}

--- a/json/twotypes.json
+++ b/json/twotypes.json
@@ -1,0 +1,201 @@
+{
+  "btf_kinds":[
+    {
+      "id": 0,
+      "kind_type": "BTF_KIND_VOID"
+    },
+    {
+      "id": 5,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 3,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 2,
+                "kind_type": "BTF_KIND_FWD",
+                "name":"ctx",
+                "is_struct":0
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 4,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 6,
+              "kind_type": "BTF_KIND_STRUCT",
+              "name":"ebpf_map",
+              "size":28,
+              "members":[
+                {
+                  "name":"type",
+                  "offset":0,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"key_size",
+                  "offset":32,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"value_size",
+                  "offset":64,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"max_entries",
+                  "offset":96,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"map_flags",
+                  "offset":128,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"inner_map_idx",
+                  "offset":160,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                },
+                {
+                  "name":"numa_node",
+                  "offset":192,
+                  "type":{
+                    "id": 7,
+                    "kind_type": "BTF_KIND_TYPEDEF",
+                    "name":"uint32_t",
+                    "type":{
+                      "id": 8,
+                      "kind_type": "BTF_KIND_INT",
+                      "name":"",
+                      "size":4,
+                      "bits_offset":0,
+                      "is_signed":0,
+                      "is_char":0,
+                      "is_bool":0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/json/wronghelper.json
+++ b/json/wronghelper.json
@@ -1,0 +1,200 @@
+{
+  "btf_kinds":[
+    {
+      "id": 4,
+      "kind_type": "BTF_KIND_FUNC",
+      "name":"func",
+      "type":{
+        "id": 2,
+        "kind_type": "BTF_KIND_FUNC_PROTO",
+        "parameters":[
+          {
+            "name":"ctx",
+            "type":{
+              "id": 1,
+              "kind_type": "BTF_KIND_PTR",
+              "type":{
+                "id": 0,
+                "kind_type": "BTF_KIND_VOID"
+              }
+            }
+          }
+        ],
+        "return_type":{
+          "id": 3,
+          "kind_type": "BTF_KIND_INT",
+          "name":"",
+          "size":4,
+          "bits_offset":0,
+          "is_signed":1,
+          "is_char":0,
+          "is_bool":0
+        }
+      }
+    },
+    {
+      "id": 10,
+      "kind_type": "BTF_KIND_DATASEC",
+      "name":"",
+      "size":0,
+      "data":[
+        {
+          "offset":0,
+          "size":28,
+          "type":{
+            "id": 9,
+            "kind_type": "BTF_KIND_VAR",
+            "name":"map",
+            "linkage":1,
+            "type":{
+              "id": 5,
+              "kind_type": "BTF_KIND_TYPEDEF",
+              "name":"bpf_map_def_t",
+              "type":{
+                "id": 6,
+                "kind_type": "BTF_KIND_STRUCT",
+                "name":"bpf_map",
+                "size":28,
+                "members":[
+                  {
+                    "name":"type",
+                    "offset":0,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"key_size",
+                    "offset":32,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"value_size",
+                    "offset":64,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"max_entries",
+                    "offset":96,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"map_flags",
+                    "offset":128,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"inner_map_idx",
+                    "offset":160,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  },
+                  {
+                    "name":"numa_node",
+                    "offset":192,
+                    "type":{
+                      "id": 7,
+                      "kind_type": "BTF_KIND_TYPEDEF",
+                      "name":"uint32_t",
+                      "type":{
+                        "id": 8,
+                        "kind_type": "BTF_KIND_INT",
+                        "name":"",
+                        "size":4,
+                        "bits_offset":0,
+                        "is_signed":0,
+                        "is_char":0,
+                        "is_bool":0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add expected BTF data for sample files. This is needed for https://github.com/vbpf/ebpf-verifier/issues/394.

