### PR TITLE
Remove dependency on Linux headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,17 @@
 cmake_minimum_required(VERSION 3.10)
 project(ebpf_samples)
 
+include(FetchContent)
+
+# libbpf is dual licensed under the GPL and the BSD license.  We use the BSD license.
+FetchContent_Declare(
+  libbpf
+  GIT_REPOSITORY https://github.com/libbpf/libbpf.git
+  GIT_TAG v1.2.0   
+)
+
+FetchContent_MakeAvailable(libbpf)
+
 add_custom_target(samples ALL
                   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/build/badhelpercall.o
                           ${CMAKE_CURRENT_SOURCE_DIR}/build/badmapptr.o
@@ -36,104 +47,104 @@ add_custom_target(samples ALL
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/badhelpercall.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/badhelpercall.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/badhelpercall.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/badhelpercall.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/badhelpercall.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/badhelpercall.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/badmapptr.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/badmapptr.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/badmapptr.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/badmapptr.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/badmapptr.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/badmapptr.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/badrelo.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/badrelo.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/badrelo.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/badrelo.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/badrelo.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/badrelo.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/byteswap.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/byteswap.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/byteswap.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/byteswap.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/byteswap.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/byteswap.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/ctxoffset.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/ctxoffset.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/ctxoffset.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/ctxoffset.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/ctxoffset.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/ctxoffset.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/exposeptr.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/exposeptr.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/exposeptr.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/exposeptr.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/exposeptr.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/exposeptr.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/exposeptr2.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/exposeptr2.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/exposeptr2.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/exposeptr2.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/exposeptr2.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/exposeptr2.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/loop.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/loop.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/loop.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/loop.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/loop.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/loop.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/mapoverflow.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/mapoverflow.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/mapoverflow.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/mapoverflow.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/mapoverflow.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/mapoverflow.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/mapunderflow.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/mapunderflow.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/mapunderflow.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/mapunderflow.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/mapunderflow.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/mapunderflow.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/mapvalue-overrun.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/mapvalue-overrun.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/mapvalue-overrun.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/mapvalue-overrun.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/mapvalue-overrun.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/mapvalue-overrun.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/map_in_map.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/map_in_map.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/map_in_map.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/map_in_map.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/map_in_map.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/map_in_map.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/map_in_map_legacy.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/map_in_map_legacy.c
-                   COMMAND clang -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/map_in_map_legacy.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/map_in_map_legacy.o)
+                   COMMAND clang -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/map_in_map_legacy.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/map_in_map_legacy.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/nullmapref.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/nullmapref.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/nullmapref.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/nullmapref.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/nullmapref.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/nullmapref.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/stackok.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/stackok.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/stackok.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/stackok.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/stackok.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/stackok.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_access.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_access.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_access.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_access.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_access.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_access.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_start_ok.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_start_ok.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_start_ok.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_start_ok.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_start_ok.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_start_ok.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_overflow.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_overflow.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_overflow.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_overflow.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_overflow.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_overflow.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_reallocate.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_reallocate.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_reallocate.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_reallocate.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/packet_reallocate.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/packet_reallocate.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/ringbuf_uninit.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/ringbuf_uninit.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/ringbuf_uninit.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/ringbuf_uninit.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/ringbuf_uninit.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/ringbuf_uninit.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/tail_call.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/tail_call.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/tail_call.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/tail_call.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/tail_call.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/tail_call.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/tail_call_bad.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/tail_call_bad.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/tail_call_bad.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/tail_call_bad.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/tail_call_bad.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/tail_call_bad.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/twomaps.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/twomaps.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/twomaps.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/twomaps.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/twomaps.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/twomaps.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/twostackvars.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/twostackvars.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c -g ${CMAKE_CURRENT_SOURCE_DIR}/src/twostackvars.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/twostackvars.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c -g ${CMAKE_CURRENT_SOURCE_DIR}/src/twostackvars.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/twostackvars.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/twotypes.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/twotypes.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/twotypes.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/twotypes.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/twotypes.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/twotypes.o)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/wronghelper.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/wronghelper.c
-                   COMMAND clang -g -target bpf -Wall -O2 -c ${CMAKE_CURRENT_SOURCE_DIR}/src/wronghelper.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/wronghelper.o)
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src -c ${CMAKE_CURRENT_SOURCE_DIR}/src/wronghelper.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/wronghelper.o)

--- a/src/bpf.h
+++ b/src/bpf.h
@@ -5,6 +5,47 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
-#include <linux/bpf.h>
-#include <bpf/bpf_helpers.h>
+
 #include <stdint.h>
+
+typedef uint8_t __u8;
+typedef uint16_t __u16;
+typedef uint32_t __u32;
+typedef uint64_t __u64;
+
+typedef int8_t __s8;
+typedef int16_t __s16;
+typedef int32_t __s32;
+typedef int64_t __s64;
+
+typedef __u16 __be16;
+typedef __u32 __be32;
+typedef __u64 __be64;
+
+typedef __u32 __wsum;
+
+enum bpf_map_type {
+	BPF_MAP_TYPE_UNSPEC = 0,
+	BPF_MAP_TYPE_HASH = 1,
+	BPF_MAP_TYPE_ARRAY = 2,
+	BPF_MAP_TYPE_PROG_ARRAY = 3,
+	BPF_MAP_TYPE_ARRAY_OF_MAPS = 12,
+	BPF_MAP_TYPE_RINGBUF = 27,
+};
+
+struct xdp_md {
+    uint32_t data;
+    uint32_t data_end;
+    uint32_t data_meta;
+    uint32_t _1;
+    uint32_t _2;
+    uint32_t _3;
+};
+
+typedef struct __sk_buff {
+    uint32_t _[19];
+    uint32_t data;
+    uint32_t data_end;
+} sk_buff;
+
+#include <bpf_helpers.h>


### PR DESCRIPTION
Building the samples on Windows was inadvertently broken by taking a dependency on the Linux headers.

This PR uses the libbpf headers instead of the Linux headers to build the sample programs.