### PR TITLE
Add `map_sequential_lookup_unsafe` sample program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,8 @@ add_custom_target(samples ALL
                           ${CMAKE_CURRENT_SOURCE_DIR}/build/perf_event_array.o
                           ${CMAKE_CURRENT_SOURCE_DIR}/build/sockmap.o
                           ${CMAKE_CURRENT_SOURCE_DIR}/build/global_func.o
-                          ${CMAKE_CURRENT_SOURCE_DIR}/build/bpf_loop_helper.o)
+                          ${CMAKE_CURRENT_SOURCE_DIR}/build/bpf_loop_helper.o
+                          ${CMAKE_CURRENT_SOURCE_DIR}/build/map_sequential_lookup_unsafe.o)
 
 # We use custom commands here so that the same command will be used on
 # Linux and Windows (where cmake would normally use cl instead of clang).
@@ -291,3 +292,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/global_func.o
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/bpf_loop_helper.o
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/bpf_loop_helper.c
                    COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src ${BPF_EXTRA_INCLUDES} -c ${CMAKE_CURRENT_SOURCE_DIR}/src/bpf_loop_helper.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/bpf_loop_helper.o)
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/build/map_sequential_lookup_unsafe.o
+                   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/map_sequential_lookup_unsafe.c
+                   COMMAND clang -g -target bpf -Wall -O2 -I ${libbpf_SOURCE_DIR}/src ${BPF_EXTRA_INCLUDES} -c ${CMAKE_CURRENT_SOURCE_DIR}/src/map_sequential_lookup_unsafe.c -o ${CMAKE_CURRENT_SOURCE_DIR}/build/map_sequential_lookup_unsafe.o)

--- a/src/map_sequential_lookup_unsafe.c
+++ b/src/map_sequential_lookup_unsafe.c
@@ -1,0 +1,52 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+// Regression test for assign_valid_ptr svalue havoc bug (soundness).
+//
+// This program is intentionally UNSAFE and must be REJECTED by the verifier.
+// It performs two sequential bpf_map_lookup_elem calls on a hash map with a
+// null-check only on the first result. On the second lookup's null branch it
+// dereferences the result without a null check -- an invalid memory access.
+//
+// With the assign_valid_ptr svalue bug, the verifier failed to havoc the
+// signed value (svalue) of the destination register before constraining it.
+// After the first lookup + null-check narrowed svalue to >0, the second
+// lookup inherited that stale constraint, making the null branch appear
+// unreachable (bottom). The verifier therefore skipped all safety checks
+// on that path, allowing this unsafe program to pass verification.
+//
+// With the fix (havoc svalue before constraining), the second null branch
+// is correctly analyzed and the verifier rejects the program.
+
+#include "bpf.h"
+
+__attribute__((section(".maps"), used))
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, uint32_t);
+    __type(value, uint32_t);
+    __uint(max_entries, 2);
+} map;
+
+int func(void* ctx)
+{
+    uint32_t key_0 = 0;
+    uint32_t key_1 = 1;
+
+    // First lookup plus null check narrows r0 to non-null on this path.
+    uint32_t* val_0 = bpf_map_lookup_elem(&map, &key_0);
+    if (!val_0) {
+        return -1;
+    }
+
+    // Second lookup result is nullable for hash maps.
+    uint32_t* val_1 = bpf_map_lookup_elem(&map, &key_1);
+    if (!val_1) {
+        // BUG TRIGGER: dereference null pointer in the null branch.
+        // Without the svalue havoc fix, the verifier marks this branch
+        // as unreachable and misses the unsafe dereference.
+        return (int)(*(volatile uint32_t*)val_1);
+    }
+
+    return (int)(*val_0 + *val_1);
+}


### PR DESCRIPTION
## Summary

Add a new BPF sample program that exercises a soundness regression in the prevail verifier's `assign_valid_ptr` function.

## Motivation

This sample is needed as a regression test for [vbpf/prevail#1149](https://github.com/vbpf/prevail/pull/1149), which fixes a bug where stale `svalue` constraints leaked across helper call boundaries, causing the verifier to incorrectly mark reachable branches as unreachable (false PASS).

## Program description

`map_sequential_lookup_unsafe.c` is **intentionally unsafe** and must be **rejected** by the verifier. It performs two sequential `bpf_map_lookup_elem` calls on a hash map:

1. First lookup result is null-checked — narrows `r0` to non-null on the success path.
2. Second lookup result is **not** null-checked on the null branch — it dereferences a null pointer.

Without the verifier fix, stale signed-value constraints from the first lookup's null-check make the second lookup's null branch appear unreachable, hiding the unsafe dereference.

## Files changed

| File | Description |
|------|-------------|
| `src/map_sequential_lookup_unsafe.c` | New BPF C source |
| `CMakeLists.txt` | Add build target for `map_sequential_lookup_unsafe.o` |

## Testing

Built locally with `cmake --build` — compiles cleanly with `clang -target bpf -O2`.